### PR TITLE
Combine docker image into one unified service with skin, core, and pit (optionally).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Build snake-skin
+FROM node:12.13.1-alpine as builder
+WORKDIR /snake-skin
+COPY snake-skin/package.json /snake-skin
+RUN npm install
+COPY snake-skin /snake-skin
+RUN npm run build
+
+
+# Build system
+FROM debian:buster-20191118-slim
+RUN apt update \
+    && apt install -y \
+        nginx git libfuzzy-dev python3 python3-pip ssdeep \
+    && rm -rf /var/lib/apt \
+    && rm -rf /var/cache/apt \
+    # nginx logs forward
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    # user and directories
+    && useradd -u 2000 -r -s /sbin/nologin -d /var/cache/snake snaked \
+    && mkdir -p /etc/snake/scales \
+    && mkdir -p /var/run/snake \
+    && mkdir -p /var/cache/snake \
+    && mkdir -p /var/db/snake \
+    && mkdir -p /var/log/snake \
+    && mkdir -p /var/log/snake-pit \
+    && mkdir -p /var/lib/snake/scales \
+    && chown snaked:snaked -R /etc/snake \
+    && chown snaked:snaked -R /etc/snake/scales \
+    && chown snaked:snaked -R /var/run/snake \
+    && chown snaked:snaked -R /var/cache/snake \
+    && chown snaked:snaked -R /var/db/snake \
+    && chown snaked:snaked -R /var/log/snake \
+    && chown snaked:snaked -R /var/log/snake-pit \
+    && chown snaked:snaked -R /var/lib/snake/scales
+
+COPY snake-core /tmp/snake
+RUN pip3 install /tmp/snake[ssdeep] \
+    && cp /tmp/snake/snake/data/config/snake.conf /etc/snake/snake.conf
+
+COPY docker/entrypoint.sh /entrypoint.sh
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder /snake-skin/dist /var/www/snake-skin
+
+VOLUME [ "/etc/snake", "/var/db/snake", "/var/lib/snake" ]
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["snake"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,72 +1,79 @@
 version: "3"
-services:
-  redis:
-    image: redis:latest
-    networks:
-      - snake
-
-  mongo:
-    image: mongo:latest
-    networks:
-      - snake
-    volumes:
-      - mongodb:/data/db
-
-  snake:
-    build:
-      context: ./snake-core/
-      dockerfile: docker/Dockerfile.snake
-    networks:
-      - snake
-    ports:
-      - "5000:5000"
-    environment:
-      - MONGODB_ADDRESS=mongo
-      - MONGODB_PORT=27017
-      - REDIS_ADDRESS=redis
-      - REDIS_PORT=6379
-    volumes:
-      - conf:/etc/snake/scales
-      - samples:/var/db/snake
-      - scales:/var/lib/snake/scales
-
-  snake-pit:
-    build:
-      context: ./snake-core/
-      dockerfile: docker/Dockerfile.pit
-    deploy:
-      replicas: 1
-    networks:
-      - snake
-    environment:
-      - MONGODB_ADDRESS=mongo
-      - MONGODB_PORT=27017
-      - REDIS_ADDRESS=redis
-      - REDIS_PORT=6379
-    volumes:
-      - conf:/etc/snake/scales
-      - samples:/var/db/snake
-      - scales:/var/lib/snake/scales
-
-  snake-skin:
-    build:
-      context: ./snake-skin/
-      dockerfile: docker/Dockerfile
-    depends_on:
-      - snake
-    networks:
-      - snake
-    ports:
-      - "8080:80"
-    environment:
-      - SNAKE_ADDRESS=snake
-      - SNAKE_PORT=5000
-
-networks:
-  snake:
 
 volumes:
   conf:
   mongodb:
   samples:
   scales:
+
+services:
+  redis:
+    image: redis:latest
+
+  mongo:
+    image: mongo:latest
+    volumes:
+      - mongodb:/data/db
+
+  ## Comment out to run core and pit as separate services (and uncomment below)
+  snake:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    depends_on:
+      - mongo
+      - redis
+    ports:
+      - "5000:5000"
+      - "8080:80"
+    environment:
+      - MONGODB_ADDRESS=mongo
+      - MONGODB_PORT=27017
+      - REDIS_ADDRESS=redis
+      - REDIS_PORT=6379
+    volumes:
+      - conf:/etc/snake/scales
+      - samples:/var/db/snake
+      - scales:/var/lib/snake/scales
+    
+  ## Uncomment to run core separately
+  # snake-core:
+  #   build:
+  #     context: .
+  #     dockerfile: docker/Dockerfile
+  #   depends_on:
+  #     - mongo
+  #     - redis
+  #   ports:
+  #     - "5000:5000"
+  #     - "8080:80"
+  #   environment:
+  #     - MONGODB_ADDRESS=mongo
+  #     - MONGODB_PORT=27017
+  #     - REDIS_ADDRESS=redis
+  #     - REDIS_PORT=6379
+  #   volumes:
+  #     - conf:/etc/snake/scales
+  #     - samples:/var/db/snake
+  #     - scales:/var/lib/snake/scales
+  #   command: snake-core
+
+  ## Uncomment to run workers separately
+  # snake-pit:
+  #   build:
+  #     context: .
+  #     dockerfile: docker/Dockerfile
+  #   depends_on:
+  #     - mongo
+  #     - redis
+  #   replicas: 1
+  #   environment:
+  #     - MONGODB_ADDRESS=mongo
+  #     - MONGODB_PORT=27017
+  #     - REDIS_ADDRESS=redis
+  #     - REDIS_PORT=6379
+  #   volumes:
+  #     - conf:/etc/snake/scales
+  #     - samples:/var/db/snake
+  #     - scales:/var/lib/snake/scales
+  #   command: snake-pit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN apt update \
     && mkdir -p /var/cache/snake \
     && mkdir -p /var/db/snake \
     && mkdir -p /var/log/snake \
-    && mkdir -p /var/log/snake-pit \
     && mkdir -p /var/lib/snake/scales \
     && chown snaked:snaked -R /etc/snake \
     && chown snaked:snaked -R /etc/snake/scales \
@@ -32,8 +31,7 @@ RUN apt update \
     && chown snaked:snaked -R /var/cache/snake \
     && chown snaked:snaked -R /var/db/snake \
     && chown snaked:snaked -R /var/log/snake \
-    && chown snaked:snaked -R /var/log/snake-pit \
-    && chown snaked:snaked -R /var/lib/snake/scales
+    && chown snaked:snaked -R /var/lib/snake
 
 COPY snake-core /tmp/snake
 RUN pip3 install /tmp/snake[ssdeep] \
@@ -43,7 +41,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /snake-skin/dist /var/www/snake-skin
 
-VOLUME [ "/etc/snake", "/var/db/snake", "/var/lib/snake" ]
+VOLUME [ "/etc/snake", "/var/db/snake", "/var/lib/snake/scales" ]
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["snake"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Dirty magic to enable peristent scales
+export SNAKE_PYTHON_DIR=/var/lib/snake/scales
+export PYTHONPATH="/var/lib/snake/scales/lib/python`python3 -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))"`/site-packages"
+
+if [ "$1" = 'snake' ]; then
+  sed -i 's/address: 127.0.0.1/address: 0.0.0.0/' /etc/snake/snake.conf
+
+  if [ $MONGODB_ADDRESS ] && [ $MONGODB_PORT ]; then
+    sed -i "s/mongodb: \"mongodb:\/\/localhost:27017\"/mongodb: \"mongodb:\/\/$MONGODB_ADDRESS:$MONGODB_PORT\"/" /etc/snake/snake.conf
+  else
+    echo "Please pass values for the MONGODB_ADDRESS and MONGODB_PORT"
+    exit 1
+  fi
+
+  if [ $REDIS_ADDRESS ] && [ $REDIS_PORT ]; then
+    sed -i "s/backend: 'redis:\/\/localhost:6379'/backend: 'redis:\/\/$REDIS_ADDRESS:$REDIS_PORT'/" /etc/snake/snake.conf
+    sed -i "s/broker: 'redis:\/\/localhost:6379\/0'/broker: 'redis:\/\/$REDIS_ADDRESS:$REDIS_PORT\/0'/" /etc/snake/snake.conf
+  else
+    echo "Please pass values for the REDIS_ADDRESS and REDIS_PORT"
+    exit 1
+  fi
+
+  if [ $HTTP_PROXY ]; then
+    sed -i "s/http_proxy: null/http_proxy: $HTTP_PROXY/" /etc/snake/snake.conf
+  fi
+  if [ $HTTPS_PROXY ]; then
+    sed -i "s/https_proxy: null/https_proxy: $HTTPS_PROXY/" /etc/snake/snake.conf
+  fi
+
+  if [ $SNAKE_COMMAND_AUTORUNS ]; then
+    sed -i "s/command_autoruns: True/command_autoruns: $SNAKE_COMMAND_AUTORUNS/" /etc/snake/snake.conf
+  fi
+
+  if [ $SNAKE_SCALES_DIR ]; then
+    sed -i "s/snake_scale_dirs: ['\/home\/alex\/Developer\/snake-scales']/snake_scale_dirs: [$SNAKE_SCALES_DIR]/" /etc/snake/snake.conf
+  fi
+
+  if [ $SNAKE_STRIP_EXTENSION ]; then
+    sed -i "s/strip_extensions: ['inactive', 'infected', 'safety']/strip_extensions: [$SNAKE_STRIP_EXTENSION]/" /etc/snake/snake.conf
+  fi
+
+  if [ $SNAKE_ZIP_PASSWORDS ]; then
+    sed -i "s/zip_passwords: ['inactive', 'infected', 'password']/zip_passwords: [$SNAKE_ZIP_PASSWORDS]/" /etc/snake/snake.conf
+  fi
+
+  # Ensure that mountpoints are owned by us
+  chown -R snaked:snaked /etc/snake
+  chown -R snaked:snaked /var/db/snake
+  chown -R snaked:snaked /var/lib/snake
+
+  # Run nginx in background
+  nginx
+
+  # Run a snake pit in background as snaked
+#   CELERYD_LOG_LEVEL="INFO"
+#   CELERYD_OPTS="--concurrency=8"
+#   exec /usr/local/bin/celery worker -A snake.worker --uid snaked --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS} --pidfile="/var/run/snake/%n.pid" --detach
+
+  # Run snake as the user snaked
+  exec runuser -u snaked -- /usr/local/bin/snaked -d
+fi
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -54,9 +54,13 @@ if [ "$1" = 'snake' ]; then
   nginx
 
   # Run a snake pit in background as snaked
-#   CELERYD_LOG_LEVEL="INFO"
-#   CELERYD_OPTS="--concurrency=8"
-#   exec /usr/local/bin/celery worker -A snake.worker --uid snaked --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS} --pidfile="/var/run/snake/%n.pid" --detach
+  (
+    CELERYD_LOG_LEVEL="INFO"
+    CELERYD_OPTS="--concurrency=8 "
+    CELERYD_PIDFILE="/var/run/snake/%n.pid"
+    CELERYD_LOGFILE="/var/log/snake/%n%I.log"
+    exec /usr/local/bin/celery worker -A snake.worker --uid snaked --pidfile=${CELERYD_PIDFILE} --loglevel=${CELERYD_LOG_LEVEL} -f ${CELERYD_LOGFILE} ${CELERYD_OPTS} --detach
+  )
 
   # Run snake as the user snaked
   exec runuser -u snaked -- /usr/local/bin/snaked -d

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,24 @@
+events {}
+
+http {
+  default_type  application/octet-stream;
+  include       /etc/nginx/mime.types;
+
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+
+  upstream snake {
+    server localhost:5000;
+  }
+
+  server {
+    listen 80;
+    location ~ /api/(.*) {
+      proxy_pass  http://snake/$1$is_args$args;
+    }
+    location / {
+      root /var/www/snake-skin;
+      try_files $uri /index.html;
+    }
+  }
+}


### PR DESCRIPTION
Thought snake-skin and snake-core are closely tied together so would be helpful to combine them in a single docker image. As a benefit, makes it a lot easier to run snake without a docker-compose.

This PR combines snake-skin, snake-core, and snake-pit into one docker image to make it easier to launch. Left a way to run snake-core and snake-pit separately as well via the entrypoint.sh with `snake-core` and `snake-pit` commands.

Changes:
- Adds docker/Dockerfile with snake-skin and snake-core.
- Adds docker/entrypoint.sh to run snake-skin, and `snake-core` or `snake-pit` or both
- Adds docker/nginx.conf with snake-skin, with proxy pass to snake-core via /api
- Gave snake-pit a `SNAKE_PIT_CONCURRENCY` env variable for fine-tuning
- Updated docker-compose.yml to run one service instead of three separate services
